### PR TITLE
Parse login page URL from initial submission

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='cmu_auth',
-      version='0.1.6',
+      version='0.1.7',
       description='Simple python methods for authenticating to Carnegie Mellon Unversity services.',
       url='https://github.com/willcrichton/cmu_auth',
       author='Will Crichton',


### PR DESCRIPTION
It seems like CMU has removed the Stateless Login page, so instead I parse out the target login page from our first get request. This should be a bit more robust for the future.

Tested with Python 2.7.9 and 3.4.3 on these URLs:

```
https://s3.andrew.cmu.edu/sio/index.html
https://enr-apps.as.cmu.edu/
https://enr-apps.as.cmu.edu/audit/audit
https://cmu.smartevals.com/secure/Login.aspx
```

This resolves #3.
